### PR TITLE
Update riseofthetriad.dk link to the mirrored version from Duke Nukem Central.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ make
 ## Sources
 
 - [icculus.org/rott/](https://icculus.org/rott/)
-- [riseofthetriad.dk](https://www.riseofthetriad.dk)
+- [riseofthetriad.dk](https://dukenukemcentral.com/mirrorsites/www.riseofthetriad.dk/)
 - [github.com/fabiangreffrath/rott/](https://github.com/fabiangreffrath/rott/)
 - [github.com/hogsy/hrotte/](https://github.com/hogsy/hrotte/)
 - [github.com/LTCHIPS/rottexpr/](https://github.com/LTCHIPS/rottexpr/)


### PR DESCRIPTION
The original domain died on September 2023 due to increased hosting cost. Me and Z helped mirror the site to Duke Nukem Central for those still needing access to it's contents.